### PR TITLE
FLOW-271: Power Automate: Unable to turn off and turn back on, a flow, that uses connect trigger

### DIFF
--- a/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
+++ b/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
@@ -201,6 +201,35 @@
         "x-ms-no-generic-test": true
       }
     },
+    "/accounts/{accountId}/connectV2/{connectId}": {
+      "delete": {
+        "summary": "Delete hook (V2)",
+        "description": "Delete a hook.",
+        "operationId": "DeleteHookV2",
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "internal",
+        "x-ms-no-generic-test": true
+      }
+    },    
     "/webhook_response": {
       "post": {
         "operationId": "WebhookResponse",

--- a/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
+++ b/certified-connectors/DocuSignDemo/apiDefinition.swagger.json
@@ -229,7 +229,36 @@
         "x-ms-visibility": "internal",
         "x-ms-no-generic-test": true
       }
-    },    
+    },
+    "/accounts/{accountId}/connectV3/{connectId}": {
+      "delete": {
+        "summary": "Delete hook (V3)",
+        "description": "Delete a hook.",
+        "operationId": "DeleteHookV3",
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "internal",
+        "x-ms-no-generic-test": true
+      }
+    },
     "/webhook_response": {
       "post": {
         "operationId": "WebhookResponse",

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -1413,6 +1413,13 @@ public class Script : ScriptBase
   {
     await this.UpdateApiEndpoint().ConfigureAwait(false);
 
+    if("DeleteHookV2".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))
+    {
+      var uriBuilder = new UriBuilder(this.Context.Request.RequestUri);
+      uriBuilder.Path = uriBuilder.Path.Replace("connectV2", "connect");
+      this.Context.Request.RequestUri = uriBuilder.Uri;
+    }
+    
     if ("SendDraftEnvelope".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))
     {
       this.Context.Request.Content = new StringContent("{ \"status\": \"sent\" }", Encoding.UTF8, "application/json");

--- a/certified-connectors/DocuSignDemo/script.csx
+++ b/certified-connectors/DocuSignDemo/script.csx
@@ -1419,7 +1419,14 @@ public class Script : ScriptBase
       uriBuilder.Path = uriBuilder.Path.Replace("connectV2", "connect");
       this.Context.Request.RequestUri = uriBuilder.Uri;
     }
-    
+
+    if("DeleteHookV3".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))
+    {
+      var uriBuilder = new UriBuilder(this.Context.Request.RequestUri);
+      uriBuilder.Path = uriBuilder.Path.Replace("connectV3", "connect");
+      this.Context.Request.RequestUri = uriBuilder.Uri;
+    }
+
     if ("SendDraftEnvelope".Equals(this.Context.OperationId, StringComparison.OrdinalIgnoreCase))
     {
       this.Context.Request.Content = new StringContent("{ \"status\": \"sent\" }", Encoding.UTF8, "application/json");


### PR DESCRIPTION
JIRA: https://jira.corp.docusign.com/browse/FLOW-271

After several debugging sessions with Microsoft we found the root cause.

The 'resource not found' error was being thrown when we turn off the flow.

Microsoft Power Automate, calls DELETE API on the web hook, whenever the user turns off the flow.

DELETE was never implemented on the v2 trigger. Once we added the delete operation, the turn off works as expected.

The behavior before was.

- When we turn off the flow, the 'resource not found' error will be thrown
- When we turn back on the flow, a new connect config will be created (essentially creating a dupe)

The behavior after the fix is.

- When we turn off the flow, the connect config will be deleted
- When we turn back on the flow, a new connect config will be created



---
### When submitting a connector, please make sure that you follow the requirements below, otherwise your PR might be rejected. We want to make you have a well-built connector, a smooth certification experience, and your users are happy :) 

If this is your first time submitting to GitHub and you need some help, please sign up for this [session](https://forms.office.com/pages/responsepage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUMTFJWFFGVUxBNUFZQjZWRUdaOE5BMFkwNS4u). 

- [ ] I attest that the connector doesn't exist on the Power Platform today. I've verified by checking the pull requests in GitHub and by searching for the connector on the platform or in the documentation. 
- [ ] I attest that the connector works and I verified by deploying and testing all the operations. 
- [ ] I attest that I have added detailed descriptions for all operations and parameters in the swagger file.
- [ ] I attest that I have added response schemas to my actions, unless the response schema is dynamic. 
- [ ] I validated the swagger file, `apiDefinition.swagger.json`, by running `paconn validate` command.
- [ ] If this is a certified connector, I confirm that `apiProperties.json` has a valid brand color and doesn't use an invalid brand color, `#007ee5` or `#ffffff`. If this is an independent publisher connector, I confirm that I am not submitting a connector icon.

If you are an Independent Publisher, you must also attest to the following to ensure a smooth publishing process:
- [ ] I have named this PR after the pattern of "Connector Name (Independent Publisher)" ex: HubSpot Marketing (Independent Publisher)
- [ ] Within this PR markdown file, I have pasted screenshots that show: 3 unique operations (actions/triggers) working within a Flow. This can be in one flow or part of multiple flows. For each one of those flows, I have pasted in screenshots of the Flow succeeding. 
- [ ] Within this PR markdown file, I have pasted in a screenshot from the Test operations section within the Custom Connector UI.
- [ ] If the connector uses OAuth, I have provided detailed steps on how to create an app in the readme.md. 


